### PR TITLE
Fix projection matrix parameter assignment bug

### DIFF
--- a/Src/Renderer/RenderTransforms.h
+++ b/Src/Renderer/RenderTransforms.h
@@ -19,7 +19,7 @@ class RenderTransforms
 
 	void setProjection(float nearPlaneWidth, float nearPlaneHeight, float zNear, float zFar)
 		{
-		this->nearPlaneHeight = nearPlaneWidth;
+		this->nearPlaneWidth = nearPlaneWidth;
 		this->nearPlaneHeight = nearPlaneHeight;
 		this->zNear = zNear;
 		this->zFar = zFar;


### PR DESCRIPTION
## Summary
- fix wrong assignment of `nearPlaneWidth`
- keep original tab-based indentation in `RenderTransforms::setProjection`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b981d01548333aae1d23937d0c979